### PR TITLE
lighter current tab color

### DIFF
--- a/themes/OneDarkVivid.json
+++ b/themes/OneDarkVivid.json
@@ -10,7 +10,7 @@
     "editorCursor.foreground": "#528bff",
     "editorWhitespace.foreground": "#484b5b",
     "sideBar.background": "#31343f",
-    "tab.activeBackground": "#31343f",
+    "tab.activeBackground": "#41444f",
     "activityBar.background": "#31343f",
     "titleBar.activeBackground":"#31343f",
     "tab.inactiveBackground": "#31343f",


### PR DESCRIPTION
Current tab is not that much visible (text is white and bold). 
This PR aims to solve this with lighter color tab background.

Current:
![current](https://user-images.githubusercontent.com/1562400/35488125-f08c1498-0483-11e8-9773-3c70024be79e.PNG)

Proposal:
![lighter](https://user-images.githubusercontent.com/1562400/35488130-fd70ffe8-0483-11e8-831e-a0a51e2a97dd.PNG)
